### PR TITLE
Remove x > 0 (not needed) check in SAD computation

### DIFF
--- a/src/SGMStereo.cpp
+++ b/src/SGMStereo.cpp
@@ -416,7 +416,7 @@ void SGMStereo::calcPixelwiseSAD(const unsigned char* leftSobelRow, const unsign
 	}
 	for (int x = 16; x < disparityTotal_; ++x) {
 		int leftCenterValue = leftSobelRow[x];
-		int leftHalfLeftValue = x > 0 ? (leftCenterValue + leftSobelRow[x - 1])/2 : leftCenterValue;
+		int leftHalfLeftValue = (leftCenterValue + leftSobelRow[x - 1])/2;
 		int leftHalfRightValue = x < width_ - 1 ? (leftCenterValue + leftSobelRow[x + 1])/2 : leftCenterValue;
 		int leftMinValue = std::min(leftHalfLeftValue, leftHalfRightValue);
 		leftMinValue = std::min(leftMinValue, leftCenterValue);
@@ -459,7 +459,7 @@ void SGMStereo::calcPixelwiseSAD(const unsigned char* leftSobelRow, const unsign
 	}
 	for (int x = disparityTotal_; x < width_; ++x) {
 		int leftCenterValue = leftSobelRow[x];
-		int leftHalfLeftValue = x > 0 ? (leftCenterValue + leftSobelRow[x - 1])/2 : leftCenterValue;
+		int leftHalfLeftValue = (leftCenterValue + leftSobelRow[x - 1])/2;
 		int leftHalfRightValue = x < width_ - 1 ? (leftCenterValue + leftSobelRow[x + 1])/2 : leftCenterValue;
 		int leftMinValue = std::min(leftHalfLeftValue, leftHalfRightValue);
 		leftMinValue = std::min(leftMinValue, leftCenterValue);


### PR DESCRIPTION
Given the loops initial values, the check is not needed.

Also note that in the code `disparityTotal_` is enforced to be `> 0`.