### PR TITLE
Add enforce left right consistency flag

### DIFF
--- a/include/sgm_stereo/SGMStereo.h
+++ b/include/sgm_stereo/SGMStereo.h
@@ -32,6 +32,7 @@ public:
 							   const int aggregationWindowRadius);
 	void setSmoothnessCostParameters(const int smoothnessPenaltySmall, const int smoothnessPenaltyLarge);
 	void setConsistencyThreshold(const int consistencyThreshold);
+	void setEnforceLeftRightConsistency(const bool enforceLeftRightConsistency);
 
 	void initialize(const int width, const int height);
 	void compute(const cv::Mat& leftImage, const cv::Mat& rightImage, float* disparityImage);
@@ -69,6 +70,7 @@ private:
 	int smoothnessPenaltySmall_;
 	int smoothnessPenaltyLarge_;
 	int consistencyThreshold_;
+	bool enforceLeftRightConsistency_;
 
 	// Data
 	int width_;

--- a/launch/sgm_stereo_standalone.launch
+++ b/launch/sgm_stereo_standalone.launch
@@ -1,6 +1,7 @@
 <launch>
 
   <arg name="camera" default="stereo" />
+  <arg name="enforce_left_right_consistency" default="true"/>
 
   <node name="sgm_stereo" pkg="sgm_stereo" type="sgm_stereo_node">
     <remap from="left/image_rect" to="$(arg camera)/left/image_rect" />
@@ -9,6 +10,8 @@
     <remap from="right/camera_info" to="$(arg camera)/right/camera_info" />
     <remap from="disparity" to="$(arg camera)/disparity" />
     <remap from="points2" to="$(arg camera)/points2" />
+
+    <param name="enforce_left_right_consistency" value="$(arg enforce_left_right_consistency)"/>
   </node>
 
 </launch>

--- a/src/sgm_stereo_node.cpp
+++ b/src/sgm_stereo_node.cpp
@@ -133,6 +133,13 @@ StereoSGMNode::StereoSGMNode() :
     return;
   }
 
+  ros::NodeHandle nh_priv("~");
+
+  bool enforce_left_right_consistency = true;
+  nh_priv.param("enforce_left_right_consistency", enforce_left_right_consistency, enforce_left_right_consistency);
+
+  sgm.setEnforceLeftRightConsistency(enforce_left_right_consistency);
+
   sgm.initialize(l_image_msg->width, l_image_msg->height);
 
   sync_.reset(new Synchronizer(ImageSyncPolicy(5), left_image_sub_, right_image_sub_, left_info_sub_, right_info_sub_)),


### PR DESCRIPTION
This is on top of #2 , which should be merged first.

This adds a flag + param + arg to enable/disable the left-right consistency check.

This is sort of in WIP, and it might need us to split the consistency method in two, because it's also filtering out out of bound disparities in the left and right margins. I can add it to this PR, or on another one.

The flag is ON by default, so it doesn't change the default behaviour.

This is my last PR for now.