### PR TITLE
Fix crash on exit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(sgm_stereo)
 
 ## Add support for C++11, supported in ROS Kinetic and newer
 add_definitions(-std=c++11)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -O3 -msse4.2 -msse3 -msse2")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -O3 -mavx -msse4.2 -msse4.1 -msse3 -msse2")
 
 find_package(catkin REQUIRED COMPONENTS
   cv_bridge

--- a/src/sgm_stereo_node.cpp
+++ b/src/sgm_stereo_node.cpp
@@ -97,6 +97,11 @@ protected:
   ros::NodeHandle nh_;
   std::string image_encoding_;
 
+  message_filters::Subscriber<sensor_msgs::Image> left_image_sub_;
+  message_filters::Subscriber<sensor_msgs::Image> right_image_sub_;
+  message_filters::Subscriber<sensor_msgs::CameraInfo> left_info_sub_;
+  message_filters::Subscriber<sensor_msgs::CameraInfo> right_info_sub_;
+
   // Sync Policy for Images
   typedef message_filters::sync_policies::ApproximateTime<
     sensor_msgs::Image, sensor_msgs::Image,
@@ -104,11 +109,6 @@ protected:
 
   typedef message_filters::Synchronizer<ImageSyncPolicy> Synchronizer;
   boost::shared_ptr<Synchronizer> sync_;
-
-  message_filters::Subscriber<sensor_msgs::Image> left_image_sub_;
-  message_filters::Subscriber<sensor_msgs::Image> right_image_sub_;
-  message_filters::Subscriber<sensor_msgs::CameraInfo> left_info_sub_;
-  message_filters::Subscriber<sensor_msgs::CameraInfo> right_info_sub_;
 
   image_geometry::StereoCameraModel model_;
 


### PR DESCRIPTION
Moving the `message_filters` subscribers before the synchronizer prevents this crash on exit (Ctrl+C):

``` bash
terminate called after throwing an instance of 'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::lock_error> >'
  what():  boost: mutex lock failed in pthread_mutex_lock: Invalid argument
```

I've also added SSE4.1 and AVX flags to cmake.