### PR TITLE
SES-700 port pluginlib to new macro

### DIFF
--- a/src/sgm_stereo_node.cpp
+++ b/src/sgm_stereo_node.cpp
@@ -19,8 +19,7 @@
 #include "sgm_stereo/sgm_stereo_node.h"
 
 
-PLUGINLIB_DECLARE_CLASS(sgm_stereo, StereoSGMNode, sgm_stereo::StereoSGMNode, nodelet::Nodelet);
-
+PLUGINLIB_EXPORT_CLASS(sgm_stereo::StereoSGMNode, nodelet::Nodelet);
 
 namespace sgm_stereo
 {


### PR DESCRIPTION
Port all pluginlib interactions to then new support macros.
PLUGINLIB_DECLARE_CLASS has been deprecated and needs to be replaced by PLUGINLIB_EXPORT_CLASS

This is in preparation for upgrading pluginlib

@efernandez 